### PR TITLE
README.md: adding "community"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@
 The goal of this project is to demonstrate each of the technologies that have been adopted by the [Cloud Native Computing Foundation] (http://cncf.io) (CNCF) in a publicly available repository in order to facilitate their understanding through simple deployment tooling and by providing sample applications as common-ground for conversation. This project will enable replicable deployments and facilitate quantification of performance, latency, throughput, and cost between various deployment models.
 
 ## Projects
+The following projects have been incorporated into this demo program. As new projects are adopted by the CNCF, subsequently, they will be incorporated here. 
+
 1. Kubernetes - [Project] (http://kubernetes.io), [Source] (https://github.com/kubernetes/kubernetes)
 2. Prometheus - [Project] (https://prometheus.io), [Source] (https://github.com/prometheus)
+
 
 ## Sample Applications
 1. Count.ly - [Project] (https://count.ly), [Source] (https://github.com/countly/countly-server) 
@@ -26,7 +29,7 @@ Note that these are explicitly marketing demos, not reference stacks. The CNCFâ€
 A variety of deployments models will be supported. Support for each deployment model will be delivered in this order of priority:
 
 1. Local (to your machine)
-2. [CNCF Cluster] (#cncf-cluster)
+2. [CNCF Community Cluster] (#cncf-cluster)
 3. AWS
 4. Azure
 5. GCP
@@ -34,7 +37,7 @@ A variety of deployments models will be supported. Support for each deployment m
 
 Given this breadth of supported deployment models using the same sample applications, performance, cost, etc. characteristics between this variety of clusters may be compared.
 
-## CNCF Cluster <a id="cncf-cluster"></a>
+## CNCF Community Cluster <a id="cncf-cluster"></a>
 Donated by Intel, a 1,000 node cluster of servers is running in Switch, Las Vegas, to be used by the CNCF community. Visit these links for a description of the cluster [project page] (https://cncf.io/cluster) or to be involved in the [cluster community] (https://github.com/cncf/cluster). 
 
 ## Getting Started


### PR DESCRIPTION
Adding "community" to best describe the CNCF cluster.
