### PR TITLE
Deployment

### DIFF
--- a/Kubernetes/Bootstrap/Ansible/roles/kubernetes/defaults/main.yml
+++ b/Kubernetes/Bootstrap/Ansible/roles/kubernetes/defaults/main.yml
@@ -1,7 +1,4 @@
-#kubernetes_version: 1.3.5
-kubernetes_version: 1.4.0-alpha.3
-#kubernetes_version: 1.3.2
-#kubernetes_version: 1.3.6
+kubernetes_version: 1.4.4
 kubernetes_base_url: "https://storage.googleapis.com/kubernetes-release/release/v{{ kubernetes_version }}/bin/linux/amd64"
 
 

--- a/Kubernetes/Bootstrap/Ansible/roles/weave/defaults/main.yml
+++ b/Kubernetes/Bootstrap/Ansible/roles/weave/defaults/main.yml
@@ -1,4 +1,4 @@
-weave_version: 1.6.1
+weave_version: 1.7.1
 weave_url: "https://github.com/weaveworks/weave/releases/download/v{{ weave_version }}/weave"
 
 weave_launch_peers: "{% for host in groups['weave'] %}{% if host != inventory_hostname %}{{ hostvars[host].ansible_default_ipv4.address }} {% endif %}{% endfor %}"

--- a/Kubernetes/Bootstrap/Ansible/roles/weave/tasks/main.yml
+++ b/Kubernetes/Bootstrap/Ansible/roles/weave/tasks/main.yml
@@ -2,8 +2,8 @@
 - name: create directories for CNI plugin
   file: path={{ item }} state=directory mode=0755
   with_items:
-    - /opt/cni/bin 
-    - /etc/cni/net.d 
+    - /opt/cni/bin
+    - /etc/cni/net.d
 
 - name: download binary
   get_url: url="{{ weave_url }}" dest=/usr/local/bin/weave mode=a+x validate_certs=no force=true
@@ -15,7 +15,7 @@
   register: weavesetuptouch
 
 - name: register setup
-  file: path=/root/weave.setup state=touch 
+  file: path=/root/weave.setup state=touch
   when: weavesetup|succeeded and weavesetuptouch.stat.exists == False
 
 #- template: src=weave.env.j2 dest=/etc/sysconfig/weave
@@ -26,10 +26,10 @@
       dest: /usr/local/bin/weavewrap
     - src: weave.env
       dest: /etc/sysconfig/weave
-    - src: weave.service 
-      dest: /etc/systemd/system/weave.service 
-    - src: weaveproxy.service 
-      dest: /etc/systemd/system/weaveproxy.service 
+    - src: weave.service
+      dest: /etc/systemd/system/weave.service
+    - src: weaveproxy.service
+      dest: /etc/systemd/system/weaveproxy.service
 
   #notify:
   #  - reload systemd

--- a/cncfdemo-cli/cncfdemo/Deployment/distcc/README.md
+++ b/cncfdemo-cli/cncfdemo/Deployment/distcc/README.md
@@ -1,5 +1,15 @@
 ### Usage
 
-runner.sh should self configure as master or slave
-For slave that just means editing `LISTENER` in /etc/default/distcc with local ip
-For master setup DISTCC_HOSTS env variable based on k8s configmap and compile something
+runner.sh should self configure as master or slave and do approximately:
+
+```
+git clone --depth 1 git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git
+cd linux-stable && make defconfig
+
+export DISTCC_HOSTS=$(getent hosts distcc | awk '{ printf "%s,cpp,lzo ", $1 }')
+#distcc --show-hosts
+eval $(distcc-pump --startup)
+export PATH=/usr/lib/distcc:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+fakeroot make-kpkg --initrd --append-to-version=testbuild --revision=0.1 kernel_image
+```


### PR DESCRIPTION
https://github.com/weaveworks/weave-kube/issues/21
https://github.com/weaveworks/weave-kube/pull/22
-- "Fixed a bug in weave-kube where Kubernetes services were inaccessible on CentOS 7"

This is a very familiar song and dance at this point.

Easily reproducible, if you create something like a daemonset or replication controller and delete and recreate it, the k8s-controller, weave, and iptables trifecta gets out of sync. Service endpoints go missing or don't route and things start misbehaving.

This hinges on an undocumented networking settings (`/proc/sys/net/bridge/bridge-nf-call-iptables`) that the Weave minor release (1.7.1) now configures on behalf of the user where as it didn't before.

This is a classic bug.
