### PR TITLE
change maintainer to label, bump grafana version

### DIFF
--- a/Docker/Countly/Dockerfile
+++ b/Docker/Countly/Dockerfile
@@ -1,8 +1,7 @@
 FROM countly/countly-server:16.06
 
-MAINTAINER Eugene Zilman <ezilman@gmail.com>
+LABEL maintainer "Eugene Zilman <ezilman@gmail.com>"
 
 # Add custom Countly configs - these in turn come from k8s volume
 ADD ./runit/countly-api.sh /etc/service/countly-api/run
 ADD ./runit/countly-dashboard.sh /etc/service/countly-dashboard/run
-

--- a/Docker/Wrk/Dockerfile
+++ b/Docker/Wrk/Dockerfile
@@ -1,6 +1,6 @@
 FROM williamyeh/wrk:4.0.2
 
-MAINTAINER Eugene Zilman <ezilman@gmail.com>
+LABEL maintainer "Eugene Zilman <ezilman@gmail.com>"
 
 RUN apk add --update curl --no-cache
 

--- a/Docker/azure-cli/Dockerfile
+++ b/Docker/azure-cli/Dockerfile
@@ -1,5 +1,5 @@
 FROM azuresdk/azure-cli-python
-MAINTAINER "Hippie Hacker <hh@ii.coop>"
+LABEL maintainer "Hippie Hacker <hh@ii.coop>"
 COPY entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["azure"]

--- a/Docker/boinc/Dockerfile
+++ b/Docker/boinc/Dockerfile
@@ -1,15 +1,15 @@
 FROM phusion/baseimage:0.9.19
 
-MAINTAINER Eugene Zilman <ezilman@gmail.com>
+LABEL maintainer "Eugene Zilman <ezilman@gmail.com>"
 
 RUN apt update -y && \
     apt install -y boinc-client && \
-    apt-get clean &&  \ 
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* 
+    apt-get clean &&  \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN mkdir -p /var/lib/boinc-client/projects/www.worldcommunitygrid.org && \
     mkdir -p /var/lib/boinc-client/slots && \
-    chown -R boinc:boinc /var/lib/boinc-client 
+    chown -R boinc:boinc /var/lib/boinc-client
 
 ADD runner.sh /var/lib/boinc-client
 ADD attach.sh /var/lib/boinc-client

--- a/Docker/distcc-daemon/Dockerfile
+++ b/Docker/distcc-daemon/Dockerfile
@@ -1,5 +1,5 @@
 FROM zilman/kernel
-MAINTAINER Eugene Zilman <ezilman@gmail.com>
+LABEL maintainer "Eugene Zilman <ezilman@gmail.com>"
 
 RUN apt-get install -y distcc distcc-pump
 
@@ -7,4 +7,3 @@ COPY config /etc/default/distcc
 COPY runner.sh /runner.sh
 
 ENTRYPOINT ["/runner.sh"]
-

--- a/Docker/distcc-master/Dockerfile
+++ b/Docker/distcc-master/Dockerfile
@@ -1,5 +1,5 @@
 FROM zilman/kernel
-MAINTAINER Eugene Zilman <ezilman@gmail.com>
+LABEL maintainer "Eugene Zilman <ezilman@gmail.com>"
 
 RUN apt-get install -y distcc distcc-pump
 
@@ -7,4 +7,3 @@ COPY config /etc/default/distcc
 COPY runner.sh /runner.sh
 
 ENTRYPOINT ["/runner.sh"]
-

--- a/Docker/distcc/Dockerfile
+++ b/Docker/distcc/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:stable
-MAINTAINER Eugene Zilman <ezilman@gmail.com>
+LABEL maintainer "Eugene Zilman <ezilman@gmail.com>"
 
 RUN apt-get clean && apt update && apt install -y
 
@@ -11,4 +11,3 @@ COPY config /etc/default/distcc
 COPY runner.sh /runner.sh
 
 ENTRYPOINT ["/runner.sh"]
-

--- a/Docker/echo/Dockerfile
+++ b/Docker/echo/Dockerfile
@@ -1,5 +1,5 @@
 FROM zilman/falcon
-MAINTAINER Eugene Zilman <ezilman@gmail.com>
+LABEL maintainer "Eugene Zilman <ezilman@gmail.com>"
 
 COPY echo.py /app.py
 

--- a/Docker/falcon/Dockerfile
+++ b/Docker/falcon/Dockerfile
@@ -1,5 +1,5 @@
 FROM zilman/gunicorn
-MAINTAINER Eugene Zilman <ezilman@gmail.com>
+LABEL maintainer "Eugene Zilman <ezilman@gmail.com>"
 
 RUN pip install meinheld falcon
 

--- a/Docker/fluentd-kubectl/Dockerfile
+++ b/Docker/fluentd-kubectl/Dockerfile
@@ -1,5 +1,5 @@
 FROM fluent/fluentd:latest-onbuild
-MAINTAINER Eugene Zilman <ezilman@gmail.com>
+LABEL maintainer "Eugene Zilman <ezilman@gmail.com>"
 WORKDIR /home/fluent
 ENV PATH /home/fluent/.gem/ruby/2.3.0/bin:$PATH
 ENV KUBE_LATEST_VERSION="v1.4.4"
@@ -20,4 +20,3 @@ RUN apk --no-cache add sudo build-base ruby-dev && \
 
 USER fluent
 CMD exec fluentd -c /fluentd/etc/$FLUENTD_CONF -p /fluentd/plugins $FLUENTD_OPT
-

--- a/Docker/fluentd-reportstats/Dockerfile
+++ b/Docker/fluentd-reportstats/Dockerfile
@@ -1,5 +1,5 @@
 FROM fluent/fluentd:latest-onbuild
-MAINTAINER Eugene Zilman <ezilman@gmail.com>
+LABEL maintainer "Eugene Zilman <ezilman@gmail.com>"
 WORKDIR /home/fluent
 ENV PATH /home/fluent/.gem/ruby/2.3.0/bin:$PATH
 

--- a/Docker/grafana/Dockerfile
+++ b/Docker/grafana/Dockerfile
@@ -1,4 +1,4 @@
-FROM grafana/grafana:3.1.1
+FROM grafana/grafana:4.5.2
 
 RUN apt-get update && \
     apt-get install -y curl

--- a/Docker/gunicorn/Dockerfile
+++ b/Docker/gunicorn/Dockerfile
@@ -1,10 +1,8 @@
 FROM python:2.7
-MAINTAINER Eugene Zilman <ezilman@gmail.com>
+LABEL maintainer "Eugene Zilman <ezilman@gmail.com>"
 
-RUN pip install gunicorn 
+RUN pip install gunicorn
 
 COPY gunicorn_conf.py /
 
-ENTRYPOINT ["/usr/local/bin/gunicorn", "--config", "/gunicorn_conf.py"] 
-
-
+ENTRYPOINT ["/usr/local/bin/gunicorn", "--config", "/gunicorn_conf.py"]

--- a/provisioning/Dockerfile
+++ b/provisioning/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:alpine
-MAINTAINER "Denver Williams <denver@ii.coop>"
+LABEL maintainer "Denver Williams <denver@ii.coop>"
 ENV KUBECTL_VERSION=v1.5.2
 ENV HELM_VERSION=v2.4.1
 ENV GCLOUD_VERSION=150.0.0
@@ -39,7 +39,7 @@ tar xvzf helm-${HELM_VERSION}-linux-amd64.tar.gz && \
 mv linux-amd64/helm /usr/local/bin && \
 rm -rf helm-*gz linux-amd64
 
-# Install Terraform 
+# Install Terraform
 RUN wget https://releases.hashicorp.com/terraform/$TERRAFORM_VERSION/terraform_"${TERRAFORM_VERSION}"_linux_$ARC.zip
 RUN unzip terraform*.zip -d /usr/bin
 


### PR DESCRIPTION
i changed maintainer to label, since the former is deprecated.
https://docs.docker.com/engine/reference/builder/#maintainer-deprecated
I also updated the grafana version to the latest docker hub tag.
We could switch to latest, since this is for demo purposes.

All the best,

Benjamin